### PR TITLE
Change: Options to only default when undefined

### DIFF
--- a/modelo/modelo.js
+++ b/modelo/modelo.js
@@ -58,7 +58,7 @@ SOFTWARE.
 
           var y;
 
-          options = options || {};
+          options = options !== undefined ? options : {};
 
           for (y = 0; y < constructors.length; y = y + 1) {
 
@@ -140,7 +140,7 @@ SOFTWARE.
 
               myInstance.isInstance(MyConstructor); // true
 
-          It would be difficult to create an inheritance chain to deep
+          It would be difficult to create an inheritance chain so deep
           and complex that this method would cause any significant
           disruption of runtime. However, it's worth noting that it is
           a recursive function and will always run an exhaustive search.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Kevin Conway <kevinjacobconway@gmail.com> (https://github.com/kevinconway)",
   "name": "modelo",
   "description": "An isomorphic JavaScript object inheritance utility.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "homepage": "https://github.com/kevinconway/Modelo.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The input parameters for the Modelo constructors used to default
to an empty object if the given value was falsey. Now it will only
default when the given value is undefined. This allows constructors
to take in primitive values like 'false' or 'null'.

Signed-off-by: Kevin Conway kevinjacobconway@gmail.com
