### PR TITLE
Change: Constructor args to allow multiple args

### DIFF
--- a/modelo/modelo.js
+++ b/modelo/modelo.js
@@ -54,15 +54,16 @@ SOFTWARE.
           context so all references to 'this' are directed at the new
           instance being created.
         */
-        Modelo = function (options) {
+        Modelo = function () {
 
-          var y;
+          var y,
+            cArgs = Array.prototype.slice.call(arguments);
 
-          options = options !== undefined ? options : {};
+          cArgs[0] = cArgs[0] !== undefined ? cArgs[0] : {};
 
           for (y = 0; y < constructors.length; y = y + 1) {
 
-            constructors[y].call(this, options);
+            constructors[y].apply(this, cArgs);
 
           }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Kevin Conway <kevinjacobconway@gmail.com> (https://github.com/kevinconway)",
   "name": "modelo",
   "description": "An isomorphic JavaScript object inheritance utility.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "homepage": "https://github.com/kevinconway/Modelo.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously only the first argument was ever passed into the
constructors for a modelo. The original behaviour has been maintained
while adding the ability to pass in multiple, positional arguments
rather than only named parameters in an object.

Signed-off-by: Kevin Conway kevinjacobconway@gmail.com
