### PR TITLE
Add: <constructor>.super_ reference for compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ inheritance. To replace it, simply use the 'isInstance' method that gets added
 to your instances. It will return true for any base object in the inheritance
 tree.
 
+Additionally, the 'super_' attribute is still present on the new constructor in
+multiple inheritance but it only references the first prototype present in the
+call to 'inherits'. It is provided only for compatibility with `util.inherits`
+and, when using multiple inheritance, the 'super_' attribute should be avoided
+in favour of calling the target prototype directly if the form of
+`<Constructor>.prototype.<method>.call(this, ...)` or
+`<Constructor>.prototype.<method>.apply(this, ...)`.
+
 ## You Said Something About Fast?
 
 All inheritance libraries have their cost. When the overhead in question affects

--- a/modelo/modelo.js
+++ b/modelo/modelo.js
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-/*jslint node: true, indent: 2, passfail: true */
+/*jslint node: true, indent: 2, passfail: true, nomen: true */
 /*global define */
 "use strict";
 
@@ -125,6 +125,7 @@ function inherits(child, parent) {
 
   // This method brought to you by Node.js util module.
   // https://github.com/joyent/node/blob/master/lib/util.js
+  child.super_ = parent;
   child.prototype = Object.create(
     parent.prototype,
     {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Kevin Conway <kevinjacobconway@gmail.com> (https://github.com/kevinconway)",
   "name": "modelo",
   "description": "A JavaScript object inheritance utility.",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "homepage": "https://github.com/kevinconway/Modelo.js",
   "repository": {
     "type": "git",

--- a/test/modelo.spec.js
+++ b/test/modelo.spec.js
@@ -203,6 +203,7 @@ describe('The Modelo library', function () {
     e.test();
     expect(e.tested).to.be(true);
     expect(e instanceof Base).to.be(true);
+    expect(Extension.super_).to.be(Base);
 
   });
 


### PR DESCRIPTION
The util.inherits method adds a reference to the inherited prototype
to the new constructor through a 'super_' attribute. This has been
added to maintain feature compatability when using modelo in single
inheritance.