### PR TITLE
add the `license` field in `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
   "optionalDependencies": {},
   "engines": {
     "node": "*"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
We are using an automated tool[1] for checking licenses in our packages
and their dependencies. The tool works best when packages specify their
licenses in the `license` field of the `package.json` files, as written
in https://docs.npmjs.com/files/package.json#license.

From the LICENSE file in the repo, I assume this package is using the
MIT license.

Hope you don't mind this change.

Thanks!

[1] https://www.npmjs.com/package/js-green-licenses